### PR TITLE
[#4] feat: 카카오 소셜 로그인 및 JWT 발급 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,13 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -21,22 +21,30 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
     implementation 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    //유효성 검사를 위한 의존성 추가
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    //스프링 시큐리티와 OAuth2 클라이언트 의존성 추가
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+    //jwt 라이브러리 추가
     implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
+    //테스트를 위한 의존성 추가
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 tasks.named('test') {
 	useJUnitPlatform()

--- a/src/main/java/com/stockinsight/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/stockinsight/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.stockinsight.domain.user.repository;
+
+import com.stockinsight.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/stockinsight/global/security/SecurityConfig.java
+++ b/src/main/java/com/stockinsight/global/security/SecurityConfig.java
@@ -1,0 +1,43 @@
+package com.stockinsight.global.security;
+
+import com.stockinsight.global.security.oauth2.CustomOAuth2UserService;
+import com.stockinsight.global.security.oauth2.OAuth2SuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                //CSRF 공격 방어 비활성화
+                .csrf(AbstractHttpConfigurer::disable)
+                //Basic Http 비활성화
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                //세션 사용하지 않음
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        //일시적으로 모두 허용. 추후, 인증이 필요한 API는 별도로 설정할 예정
+                        .anyRequest().permitAll()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                        .successHandler(oAuth2SuccessHandler)
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/stockinsight/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/stockinsight/global/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,37 @@
+package com.stockinsight.global.security.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey key;
+    private final long expirationTime;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.expiration_time}") long expirationTime) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expirationTime = expirationTime;
+    }
+
+    public String createAccessToken(String email) {
+        // JWT 표준 스펙(RFC 7519) 준수를 위해 LocalDateTime 대신 Date 사용
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + expirationTime);
+
+        return Jwts.builder()
+                .subject(email)
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(key)
+                .compact();
+    }
+}

--- a/src/main/java/com/stockinsight/global/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/stockinsight/global/security/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,55 @@
+package com.stockinsight.global.security.oauth2;
+
+import com.stockinsight.domain.user.entity.Provider;
+import com.stockinsight.domain.user.entity.User;
+import com.stockinsight.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        //차후, 구글 로그인 추가할 때 registrationId로 구분하여 처리할 수 있도록 함
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        String providerId = String.valueOf(attributes.get("id")); // 카카오 고유 ID
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        String email = (String) kakaoAccount.get("email");
+        String name = (String) profile.get("nickname");
+
+        log.info("카카오 로그인 시도: email={}, name={}", email, name);
+
+        User user = userRepository.findByEmail(email)
+                .orElseGet(() -> saveNewUser(email, name, providerId));
+
+        return oAuth2User;
+    }
+
+    private User saveNewUser(String email, String name, String providerId) {
+        User newUser = User.builder()
+                .email(email)
+                .name(name)
+                .provider(Provider.KAKAO)
+                .providerId(providerId)
+                .build();
+        return userRepository.save(newUser);
+    }
+}

--- a/src/main/java/com/stockinsight/global/security/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/stockinsight/global/security/oauth2/OAuth2SuccessHandler.java
@@ -1,0 +1,38 @@
+package com.stockinsight.global.security.oauth2;
+
+import com.stockinsight.global.security.jwt.JwtTokenProvider;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+
+        String email = (String) kakaoAccount.get("email");
+
+        String accessToken = jwtTokenProvider.createAccessToken(email);
+        log.info("카카오 로그인 성공! 발급된 JWT 토큰: {}", accessToken);
+
+        String targetUrl = "http://localhost:8080/login-success?token=" + accessToken;
+        response.sendRedirect(targetUrl);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,28 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            client-name: Kakao
+            scope:
+              - profile_nickname
+              - account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+jwt:
+  secret: ${JWT_SECRET} # 32바이트 이상 필수
+  expiration_time: 3600000 # 1시간 (밀리초)

--- a/src/test/java/com/stockinsight/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/stockinsight/domain/user/repository/UserRepositoryTest.java
@@ -1,0 +1,62 @@
+package com.stockinsight.domain.user.repository;
+
+import com.stockinsight.domain.user.entity.Provider;
+import com.stockinsight.domain.user.entity.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("회원가입 테스트")
+    void saveUser() {
+        // given
+        User newUser = User.builder()
+                .email("test@test.com")
+                .name("테스트")
+                .provider(Provider.KAKAO)
+                .providerId("123456789")
+                .build();
+
+        // when
+        User savedUser = userRepository.save(newUser);
+
+        // then
+        assertThat(savedUser.getId()).isNotNull();
+
+        User foundUser = userRepository.findByEmail("test@test.com")
+                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 사용자입니다."));
+
+        assertThat(foundUser.getName()).isEqualTo("테스트");
+        assertThat(foundUser.getProvider()).isEqualTo(Provider.KAKAO);
+    }
+
+    @Test
+    @DisplayName("중복 가입 방지 테스트")
+    void findUser() {
+        // given
+        User existingUser = User.builder()
+                .email("test2@test.com")
+                .name("테스트2")
+                .provider(Provider.KAKAO)
+                .providerId("987654321")
+                .build();
+
+        userRepository.save(existingUser);
+
+        // when
+        boolean exists = userRepository.findByEmail("test2@test.com").isPresent();
+
+        // then
+        assertThat(exists).isTrue();
+    }
+}

--- a/src/test/java/com/stockinsight/global/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/stockinsight/global/security/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,53 @@
+package com.stockinsight.global.security.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtTokenProviderTest {
+
+    // 테스트용 임의의 키 (32글자 이상)
+    private final String secret = "testSecretKey123456789012345678901234567890";
+    private final long expirationTime = 3600000L; // 1시간
+
+    private final JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(secret, expirationTime);
+
+    @Test
+    @DisplayName("이메일 통한 JWT 토큰 생성 테스트")
+    void createToken() {
+        // given
+        String email = "test@test.com";
+
+        // when
+        String token = jwtTokenProvider.createAccessToken(email);
+
+        // then
+        System.out.println("생성된 토큰: " + token);
+        assertThat(token).isNotNull();
+        assertThat(token.length()).isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("JWT 토큰에서 이메일 추출 테스트")
+    void parseToken() {
+        // given
+        String originalEmail = "test@test.com";
+        String token = jwtTokenProvider.createAccessToken(originalEmail);
+
+        // when
+        String extractedEmail = Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8)))
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+
+        // then
+        assertThat(extractedEmail).isEqualTo(originalEmail);
+    }
+}


### PR DESCRIPTION
## 상세 구현 내역
- Security: Spring Security 전역 설정 (CSRF/Session 비활성화, OAuth2 엔드포인트 등록)
- Auth: CustomOAuth2UserService 구현 (카카오 사용자 정보 파싱 및 DB 자동 저장/로그인)
- JWT: JwtTokenProvider 구현 (HMAC-SHA256 알고리즘 기반 Access Token 발급 및 검증)
- Handler: OAuth2SuccessHandler 구현 (로그인 성공 시 토큰 발급 후 클라이언트 리다이렉트)
- Test: JWT 단위 테스트 및 UserRepository 슬라이스 테스트(H2) 작성

## 기술적 의사결정 (Technical Decisions)
1. Stateless 아키텍처 및 JWT 도입
- 서버의 확장성(Scale-out)을 고려하여 세션을 서버 메모리에 저장하지 않는 Stateless 방식을 채택했으며, 클라이언트가 토큰을 통해 스스로를 증명하는 JWT 인증 방식을 적용했습니다.

2. CSRF 비활성화
- 쿠키를 통한 세션 인증이 아닌, 클라이언트가 직접 헤더(Authorization)에 토큰을 담아 요청하는 REST API 방식이므로 브라우저의 자동 전송에 의한 CSRF 공격 가능성이 없어 해당 설정을 비활성화했습니다.

3. 테스트 전략 (Unit & Slice)
- 외부 API(Kakao) 통신에 의존하는 통합 테스트 대신, 핵심 로직의 안정성을 빠르게 검증하기 위해 JWT 로직은 순수 단위 테스트로, DB 저장은 @DataJpaTest를 활용한 슬라이스 테스트로 구현하여 실행 속도를 높였습니다.

4. Date 타입 사용 (JWT 라이브러리 스펙 준수)
- 프로젝트 전반에는 LocalDateTime을 사용하지만, jjwt 라이브러리의 표준 스펙(RFC 7519)에 맞춰 유닉스 타임스탬프를 정확히 처리하기 위해 토큰 생성 메서드 내부에서만 제한적으로 java.util.Date를 사용했습니다.

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now log in using their Kakao accounts
  * Secure authentication sessions powered by JWT tokens

* **Tests**
  * Added tests for user registration and email-based lookup functionality
  * Added tests for JWT token generation and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->